### PR TITLE
Clarify link text for Serde JSON API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ serde_json = "1.0"
 
 You may be looking for:
 
-- [JSON API documentation](https://docs.rs/serde_json)
+- [Serde JSON API documentation](https://docs.rs/serde_json)
 - [Serde API documentation](https://docs.rs/serde)
 - [Detailed documentation about Serde](https://serde.rs/)
 - [Setting up `#[derive(Serialize, Deserialize)]`](https://serde.rs/derive.html)


### PR DESCRIPTION
Clarify that the link in fact leads to the Serde JSON API docs, not json.org.